### PR TITLE
Remove unnecessary if statement with initializer

### DIFF
--- a/src/message.cc
+++ b/src/message.cc
@@ -146,11 +146,11 @@ void to_json(nlohmann::json& j, const Message& message) {
         {"name", message.name()},
     };
 
-    if (const auto t = message.temperature(); t) {
+    if (const auto t = message.temperature()) {
         j["temperature"] = *t;
     }
 
-    if (const auto h = message.humidity(); h) {
+    if (const auto h = message.humidity()) {
         j["humidity"] = *h;
     }
 }


### PR DESCRIPTION
While C++17 introduces if statements with initializers, these are
unnecessary for optional types as they can be evaluated in a boolean
context.